### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://amarobruschi.visualstudio.com/9ead8e1a-698e-4699-ad1b-0147357f11e0/d4b98d42-b48a-4f47-af82-c8595126dcf6/_apis/work/boardbadge/7fb23197-d80c-470e-90fb-7dab460fce55)](https://amarobruschi.visualstudio.com/9ead8e1a-698e-4699-ad1b-0147357f11e0/_boards/board/t/d4b98d42-b48a-4f47-af82-c8595126dcf6/Microsoft.RequirementCategory)
 # blog
 Blog Bruschi


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://amarobruschi.visualstudio.com/9ead8e1a-698e-4699-ad1b-0147357f11e0/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.